### PR TITLE
Result.ok() method

### DIFF
--- a/koda/result.py
+++ b/koda/result.py
@@ -38,6 +38,10 @@ class Ok(Generic[A]):
         """
         return Err(self.val)
 
+    @staticmethod
+    def ok() -> bool:
+        return True
+
 
 @dataclass(frozen=True)
 class Err(Generic[FailT]):
@@ -80,6 +84,10 @@ class Err(Generic[FailT]):
         Ok(val=3)
         """
         return Ok(self.val)
+
+    @staticmethod
+    def ok() -> bool:
+        return False
 
 
 Result = Union[Ok[A], Err[FailT]]

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -7,3 +7,5 @@ def test_result() -> None:
     enforce_monad_unit(Ok)
     enforce_monad_flat_map(Ok, Err("something went wrong"))
     enforce_applicative_apply(Ok, Err("something went wrong"))
+    assert Ok("whatever").ok()
+    assert not Err("whatever").ok()


### PR DESCRIPTION
Simple shortcut to check if an object is an Err or Ok. 

I was missing it since I am using koda with python 3.9 and there's no structural pattern matching so i had to call `isinstance` every time

