### PR TITLE
check for key instead of catching `KeyError` in `mapping_get`

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -31,3 +31,5 @@ jobs:
         run: poetry run pytest
       - name: linting
         run: poetry run flake8 --exclude tests/test_310.py
+      - name: benchmarks
+        run: poetry run python -m bench.run

--- a/bench/run.py
+++ b/bench/run.py
@@ -2,7 +2,7 @@ from argparse import ArgumentParser
 from time import perf_counter
 from typing import Callable, Dict
 
-from koda import Err, Just, Nothing, Ok
+from koda import Err, Just, Nothing, Ok, mapping_get
 
 
 def create_ok(iterations: int) -> None:
@@ -25,11 +25,22 @@ def create_nothing(iterations: int) -> None:
         Nothing()
 
 
+def run_mapping_get(iterations: int) -> None:
+    obj = {"a": 1, "b": 2, "c": 3}
+    for i in range(iterations // 2):
+        # misses
+        mapping_get(obj, "3")
+    for i in range(iterations // 2):
+        # hits
+        mapping_get(obj, "a")
+
+
 benches: Dict[str, Callable[[int], None]] = {
     "create_ok": create_ok,
     "create_err": create_err,
     "create_just": create_just,
     "create_nothing": create_nothing,
+    "mapping_get": run_mapping_get,
 }
 
 

--- a/koda/utils.py
+++ b/koda/utils.py
@@ -15,9 +15,11 @@ def identity(x: A) -> A:
 def mapping_get(data: Mapping[A, B], key: A) -> Maybe[B]:
     # this is better than data.get(...) because if None is a valid return value,
     # there's no way to know if the value is the value from the map or the deafult value
-    try:
+
+    # this is faster than try/except KeyError in initial testing
+    if key in data:
         return Just(data[key])
-    except KeyError:
+    else:
         return nothing
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "koda"
-version = "1.3.1"
+version = "1.3.2"
 readme = "README.md"
 description = "Type-safe functional tools for Python"
 authors = ["Keith Philpott"]


### PR DESCRIPTION
## Issue or goal of PR:
make `mapping_get` a bit faster

## What I did
- change the way `mapping_get` checks for a key
- added runner to benchmarks to demonstrate. saw about 30% improvement

## How to test
try the previous code with the benchmark runner


## Documentation
Check one:

- [ ] I updated documentation
OR
- [x] No documentation updates required
